### PR TITLE
Modify onFinish callback test

### DIFF
--- a/tests/flows/chat-flow.test.ts
+++ b/tests/flows/chat-flow.test.ts
@@ -130,11 +130,14 @@ describe('ChatFlow', () => {
       const onFinish = vi.fn();
       const flowWithCallback = new ChatFlow({ agent: mockAgent, onFinish });
 
-      const { result } = await flowWithCallback.run(mockContext);
+      const { context, result } = await flowWithCallback.run(mockContext);
       await result.consumeStream();
-      await result.steps;
+      const steps = await result.steps;
 
-      expect(onFinish).toHaveBeenCalled();
+      expect(onFinish).toHaveBeenCalledWith(
+        expect.objectContaining({ steps }),
+        context.steps[0]
+      );
     });
 
     it('should handle stream errors properly', async () => {


### PR DESCRIPTION
## Summary
- ensure that the `onFinish` callback gets the executed steps and context

## Testing
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_683fc6cb0f7c8329b27d83b22b1ed037