### PR TITLE
Fix typo and bug, improve error message and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,5 +141,5 @@ This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md
 ## TODO
 
 - [ ] Add next.js examples
-- [ ] Document pubic API and use cases
+ - [ ] Document public API and use cases
 - [ ] Inter-Agent memory

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -128,7 +128,7 @@ export abstract class AgentFlow<C extends Context> {
 
   protected createLlmTool<P extends ToolParameters>(agent: LlmAgent<C, P>, ctx: IRunContext<C>) {
     if (!agent.asTool || !agent.description) {
-      throw new Error('toolParams and description are required');
+      throw new Error('asTool and description are required');
     }
 
     const { input, getPrompt } = agent.asTool;
@@ -200,7 +200,7 @@ export abstract class AgentFlow<C extends Context> {
     return tool as Tool;
   }
 
-  public createContext<C extends Context>(ctx: C): IRunContext<C> {
+  public createContext(ctx: C): IRunContext<C> {
     return new RunFlowContext<C>(ctx);
   }
 

--- a/tests/flow.test.ts
+++ b/tests/flow.test.ts
@@ -144,7 +144,7 @@ describe('AgentFlow', () => {
 
       await expect(async () => {
         flow.testCreateLlmTool(mockAgent, stepContext);
-      }).rejects.toThrow('toolParams and description are required');
+      }).rejects.toThrow('asTool and description are required');
     });
 
     it('should create an LLM tool when configured properly', async () => {


### PR DESCRIPTION
## Summary
- fix typo in README
- correct createLlmTool error text
- rely on class generic in `createContext`
- verify tool execution in chat-flow test
- update failing test expectation
